### PR TITLE
Add support for React.Fragment to PSX

### DIFF
--- a/psx.lisp
+++ b/psx.lisp
@@ -139,7 +139,7 @@
 	     (list nil)))))
 
 (defun split-string (str delimiter)
-  (loop with substrs = '(nil)
+  (loop with substrs = (list nil)
 	for char across str
 	if (eql char delimiter)
 	  do (push nil substrs)

--- a/test.lisp
+++ b/test.lisp
@@ -50,6 +50,10 @@
 
   (test-psx
    (:fragment (:td "foo") (:td "bar"))
-   "React.createElement(React.Fragment, null, [React.DOM.td(null, 'foo'), React.DOM.td(null, 'bar')]);"))
+   "React.createElement(React.Fragment, null, [React.DOM.td(null, 'foo'), React.DOM.td(null, 'bar')]);")
+
+  (test-psx
+   (:foo.bar)
+   "React.createElement(foo.bar);"))
    
   

--- a/test.lisp
+++ b/test.lisp
@@ -32,7 +32,7 @@
     
     (test-psx
      (:span :class-name "icon")
-     "React.DOM.span({ className : 'icon' });")
+     "React.DOM.span(cl_react_mergeObjects({ className : 'icon' }));")
     
     (test-psx
      (:span "Test")
@@ -41,10 +41,15 @@
     (test-psx
      (:a :href "#"
 	 (:span "Test"))
-     "React.DOM.a({ href : '#' }, React.DOM.span(null, 'Test'));")
+     "React.DOM.a(cl_react_mergeObjects({ href : '#' }), React.DOM.span(null, 'Test'));")
     
     (test-psx
      (:p (:b "Bold")
 	 (:i "Italic"))
-     "React.DOM.p(null, [React.DOM.b(null, 'Bold'), React.DOM.i(null, 'Italic')]);"))
+     "React.DOM.p(null, [React.DOM.b(null, 'Bold'), React.DOM.i(null, 'Italic')]);")
+
+  (test-psx
+   (:fragment (:td "foo") (:td "bar"))
+   "React.createElement(React.Fragment, null, [React.DOM.td(null, 'foo'), React.DOM.td(null, 'bar')]);"))
+   
   


### PR DESCRIPTION
Hey there, Ben, it's been a while! I see you've been maintaining this project and keeping it alive, and for that I am most appreciative.

I've been revisiting the project and making some updates--most immediately adding support for Fragments and dotted keywords to PSX:

````common-lisp
(ps:ps 
  (cl-react:psx 
   (:fragment (:td "foo") 
              (:td "bar"))))

(ps:ps
  (cl-react:psx
   (:my-module.my-component :my-prop "foo")))
````
=>
````javascript

React.createElement(React.Fragment, null, [React.DOM.td(null, 'foo'), React.DOM.td(null, 'bar')]);

React.createElement(myModule.myComponent, { myProp: 'foo' });
````

I have some other changes related to React Hooks (https://github.com/helmutkian/cl-react/tree/hooks) and a few others coming down the pipeline.